### PR TITLE
Adds AutoPublish cog

### DIFF
--- a/autopublish/autopublish.py
+++ b/autopublish/autopublish.py
@@ -79,7 +79,7 @@ class AutoPublish(commands.Cog):
             if channels:
                 msg = ""
                 for channel in channels:
-                    msg += f"{channel.mention}\n"
+                    msg += f"<#{channel}>\n"
                 embed = discord.Embed(
                     title="Tracking channels",
                     description=msg,

--- a/autopublish/autopublish.py
+++ b/autopublish/autopublish.py
@@ -1,0 +1,112 @@
+import discord
+from discord.ext import commands
+
+from core import checks
+from core.models import PermissionLevel
+
+
+class AutoPublish(commands.Cog):
+    """Auto Publish messages sent in announcement channels"""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.coll = bot.plugin_db.get_partition(self)
+
+    # Credit to codeinteger6 for this command's code
+    @commands.command()
+    @checks.has_permissions(PermissionLevel.MODERATOR)
+    async def publish(self, ctx, message_id: discord.Message):
+        """Publish message sent in announcement channel.\n[Refer here](https://github.com/codeinteger6/modmail-plugins/blob/master/publish/README.md) for detailed guidance."""
+        await message_id.publish()
+        await ctx.send("Published message successfully.")
+
+    @commands.command()
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
+    async def track(self, ctx, channel: discord.TextChannel):
+        """Add announcement channels to track and auto publish announcements"""
+        if not channel.is_news():
+            return await ctx.send(
+                f"{channel.mention} is not an announcement channel to track!"
+            )
+        doc = await self.coll.find_one({"_id": ctx.guild.id})
+        if doc:
+            channels = doc["channels"]
+            if not channel.id in channels:
+                channels.append(channel.id)
+                await self.coll.update_one(
+                    {"_id": ctx.guild.id}, {"$set": {"channels": channels}}
+                )
+            else:
+                await ctx.send(f"Already tracking {channel.mention}!")
+        else:
+            channels = [channel.id]
+            await self.coll.insert_one({"_id": ctx.guild.id, "channels": channels})
+        return await ctx.send(
+            f"Successfully added {channel.mention} to tracking list! All the messages sent there will now be auto published."
+        )
+
+    @commands.command()
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
+    async def remove(self, ctx, channel: discord.TextChannel):
+        """Remove a channel from tracking"""
+        doc = await self.coll.find_one({"_id": ctx.guild.id})
+        if doc:
+            channels = doc["channels"]
+            if channel.id in channels:
+                channels.remove(channel.id)
+                await self.coll.update_one(
+                    {"_id": ctx.guild.id}, {"$set": {"channels": channels}}
+                )
+                return await ctx.send(
+                    f"Successfully removed {channel.mention} from tracking list! All the messages sent there will now not be auto published."
+                )
+            else:
+                return await ctx.send(
+                    f"{channel.mention} is not currently under tracking!"
+                )
+        else:
+            return await ctx.send(
+                f"Please atleast add one channel to tracking using `track` command before trying to remove."
+            )
+
+    @commands.command()
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
+    async def listtracks(self, ctx):
+        """List all the announcement channels that are being tracked for auto publishing"""
+        doc = await self.coll.find_one({"_id": ctx.guild.id})
+        if doc:
+            channels = doc["channels"]
+            if channels:
+                msg = ""
+                for channel in channels:
+                    msg += f"{channel.mention}\n"
+                embed = discord.Embed(
+                    title="Tracking channels",
+                    description=msg,
+                    color=discord.Color.blue(),
+                )
+                return await ctx.send(embed=embed)
+            else:
+                return await ctx.send(
+                    "Not tracking any announcement channels in this server!"
+                )
+        else:
+            return await ctx.send(
+                "Not tracking any announcement channels in this server!"
+            )
+
+    async def on_message(self, message):
+        if not message.channel.is_news():
+            return  # Not an announcements channel
+        guild_id = message.guild.id
+        doc = await self.coll.find_one({"_id": guild_id})
+        if not doc:
+            return  # No tracking channels
+        channels = doc["channels"]
+        if not message.channel.id in channels:
+            return  # Not tracking
+        await message.publish()
+
+
+def setup(bot):
+    bot.add_cog(AutoPublish(bot))

--- a/autopublish/autopublish.py
+++ b/autopublish/autopublish.py
@@ -95,6 +95,7 @@ class AutoPublish(commands.Cog):
                 "Not tracking any announcement channels in this server!"
             )
 
+    @commands.Cog.listener()
     async def on_message(self, message):
         if not message.channel.is_news():
             return  # Not an announcements channel


### PR DESCRIPTION
## AutoPublish Plugin

AutoPublish Cog has the following commands:

- `[p]track <channel>` : Used to add an Announcement channel to be tracked. This means all the messages that gets sent in that particular announcements channel get auto published.
- `[p]remove <channel>` : Remove a channel from tracking.
- `[p]listtracks` : List all the channels that are being tracked in the server. 
- `[p]publish <msgid>` : This command is from [Codeinteger6's publish plugin](https://github.com/codeinteger6/modmail-plugins/tree/master/publish). Used to publish a particular message manually. 

Add the cog using the command `[p]plugins add officialakhil/modmail-plugins/autopublish`

**Note:** You might want to uninstall the `publish` plugin to install this due to clash with the command name of `publish`. `[p]` is your bot's prefix.